### PR TITLE
Let postfix's "relayhost" variable be configured

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,9 @@ postfix_inet_interfaces: ''
 # Default mynetworks for ubuntu 18: "127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128"
 # Default mynetworks for red hat 6: "127.0.0.0/8"
 postfix_mynetworks: ''
+
+# Relayhost is normally not needed. By itself, it's probably not enough for any
+# kind of production use, or 'smart' relaying. This option was simply added so we
+# could blindly redirect all outbound mail to a local instance of Mailhog,
+# which is handled by a separate role.
+postfix_relayhost: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,7 +91,15 @@
   notify:
     - restart postfix
 
-
+- name: Set postfix value for "relayhost"
+  lineinfile:
+    dest: /etc/postfix/main.cf
+    regexp: "^relayhost = "
+    line: "relayhost = {{ postfix_relayhost }}"
+    state: present
+    backup: true
+  notify:
+    - restart postfix
 
 - name: Set postfix value for "mynetworks"
   lineinfile:


### PR DESCRIPTION
Use case: redirecting all oubtound mail to a local mailhog installation