### PR TITLE
Fix path watcher not working in production

### DIFF
--- a/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
+++ b/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
@@ -1,6 +1,6 @@
 [Path]
 Unit=etc-resolv-conf-watcher.service
-PathModified=/run/resolvconf/resolv.conf
+PathModified=/etc/resolv.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
+++ b/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
@@ -1,6 +1,6 @@
 [Path]
 Unit=etc-resolv-conf-watcher.service
-PathChanged=/run/resolvconf/resolv.conf
+PathModified=/run/resolvconf/resolv.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
+++ b/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
@@ -1,6 +1,6 @@
 [Path]
 Unit=etc-resolv-conf-watcher.path
-PathChanged=/etc/resolv.conf
+PathChanged=/run/resolvconf/resolv.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
+++ b/templates/etc/systemd/system/etc-resolv-conf-watcher.path.j2
@@ -1,5 +1,5 @@
 [Path]
-Unit=etc-resolv-conf-watcher.path
+Unit=etc-resolv-conf-watcher.service
 PathChanged=/run/resolvconf/resolv.conf
 
 [Install]


### PR DESCRIPTION
Tests on staging resulted in mail delivery after reboots, but prod mail continued to fail after reboot. It may be that the staging systems just got lucky.

See [issue discussion](https://github.com/AcroMedia/ansible-role-postfix/issues/7) for details.